### PR TITLE
Update github actions for tests

### DIFF
--- a/.github/workflows/tpp-ci.yml
+++ b/.github/workflows/tpp-ci.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: macOS-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tpp-ci.yml
+++ b/.github/workflows/tpp-ci.yml
@@ -50,6 +50,8 @@ jobs:
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 33
+        arch: x86_64
+        target: google_apis
         force-avd-creation: false
         emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: false

--- a/.github/workflows/tpp-ci.yml
+++ b/.github/workflows/tpp-ci.yml
@@ -32,6 +32,8 @@ jobs:
       uses: gradle/gradle-build-action@v2
       with:
         arguments: build
+        # Only write to the cache for builds on the 'main' and 'develop' branches. (Default is 'main' only.)
+        # Builds on other branches will only read existing entries from the cache.
         cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
   
   unit-tests:

--- a/.github/workflows/tpp-ci.yml
+++ b/.github/workflows/tpp-ci.yml
@@ -65,6 +65,9 @@ jobs:
         java-version: '11'
         distribution: 'temurin'
 
+    - name: Gradle cache
+      uses: gradle/gradle-build-action@v2
+
     - name: AVD cache
       uses: actions/cache@v3
       id: avd-cache

--- a/.github/workflows/tpp-ci.yml
+++ b/.github/workflows/tpp-ci.yml
@@ -37,7 +37,7 @@ jobs:
         arguments: build
 
     - name: Run Test
-      run: ./gradle test
+      run: ./gradlew test
 
     - name: Run Instrumental Tests
       uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/tpp-ci.yml
+++ b/.github/workflows/tpp-ci.yml
@@ -31,9 +31,7 @@ jobs:
       uses: gradle/gradle-build-action@v2
       with:
         arguments: build
-        cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/test-github-actions-with-emulator' }}
-    - name:
-      run: echo ${{ github.ref }}
+        cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/pull/34/merge' }}
   
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/tpp-ci.yml
+++ b/.github/workflows/tpp-ci.yml
@@ -56,6 +56,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
     - name: Run Instrumental Tests
       uses: reactivecircus/android-emulator-runner@v2
       with:

--- a/.github/workflows/tpp-ci.yml
+++ b/.github/workflows/tpp-ci.yml
@@ -32,6 +32,7 @@ jobs:
       with:
         arguments: build
         cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/test-github-actions-with-emulator' }}
+    - run: echo ${{ github.ref }} 
   
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/tpp-ci.yml
+++ b/.github/workflows/tpp-ci.yml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -31,7 +32,7 @@ jobs:
       uses: gradle/gradle-build-action@v2
       with:
         arguments: build
-        cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/pull/34/merge' }}
+        cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
   
   unit-tests:
     name: Unit Tests
@@ -44,8 +45,6 @@ jobs:
         distribution: 'temurin'
     - name: Build with Gradle 
       uses: gradle/gradle-build-action@v2
-      with:
-        arguments: build
 
     - name: Run Test
       run: ./gradlew test

--- a/.github/workflows/tpp-ci.yml
+++ b/.github/workflows/tpp-ci.yml
@@ -48,18 +48,43 @@ jobs:
 
   instrumental-tests:
     runs-on: macOS-latest
+    strategy:
+      matrix:
+        api-level: [29]
+
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-java@v3
       with:
         java-version: '11'
         distribution: 'temurin'
-
     - name: Build with Gradle 
       uses: gradle/gradle-build-action@v2
+
+    - name: AVD cache
+      uses: actions/cache@v3
+      id: avd-cache
+      with:
+        path: |
+          ~/.android/avd/*
+          ~/.android/adb*
+        key: avd-${{ matrix.api-level }}
+
+    - name: create AVD and generate snapshot for caching
+      if: steps.avd-cache.outputs.cache-hit != 'true'
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: ${{ matrix.api-level }}
+        force-avd-creation: false
+        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        disable-animations: false
+        script: echo "Generated AVD snapshot for caching."
+
     - name: Run Instrumental Tests
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 29
+        force-avd-creation: false
+        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: true
         script: ./gradlew connectedAndroidTest

--- a/.github/workflows/tpp-ci.yml
+++ b/.github/workflows/tpp-ci.yml
@@ -30,9 +30,19 @@ jobs:
         distribution: 'temurin'
     - name: Run gradle wrapper
       run: gradle wrapper
-    - name: Run Test
-      run: gradle clean test
+
     - name: Build with Gradle
       uses: gradle/gradle-build-action@v2
       with:
         arguments: build
+
+    - name: Run Test
+      run: ./gradle test
+
+    - name: Run Instrumental Tests
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: 33
+        arch: x86_64
+        target: google_apis
+        script: ./gradlew connectedAndroidTest

--- a/.github/workflows/tpp-ci.yml
+++ b/.github/workflows/tpp-ci.yml
@@ -32,7 +32,8 @@ jobs:
       with:
         arguments: build
         cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/test-github-actions-with-emulator' }}
-    - run: echo ${{ github.ref }} 
+    - name:
+      run: echo ${{ github.ref }}
   
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/tpp-ci.yml
+++ b/.github/workflows/tpp-ci.yml
@@ -40,9 +40,11 @@ jobs:
       with:
         java-version: '11'
         distribution: 'temurin'
-
     - name: Build with Gradle 
       uses: gradle/gradle-build-action@v2
+      with:
+        arguments: build
+
     - name: Run Test
       run: ./gradlew test
 
@@ -60,6 +62,8 @@ jobs:
         distribution: 'temurin'
     - name: Build with Gradle 
       uses: gradle/gradle-build-action@v2
+      with:
+        arguments: build
 
     - name: AVD cache
       uses: actions/cache@v3

--- a/.github/workflows/tpp-ci.yml
+++ b/.github/workflows/tpp-ci.yml
@@ -36,6 +36,25 @@ jobs:
       with:
         arguments: build
 
+    - name: AVD cache
+      uses: actions/cache@v3
+      id: avd-cache
+      with:
+        path: |
+          ~/.android/avd/*
+          ~/.android/adb*
+        key: avd-33
+
+    - name: create AVD and generate snapshot for caching
+      if: steps.avd-cache.outputs.cache-hit != 'true'
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: 33
+        force-avd-creation: false
+        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        disable-animations: false
+        script: echo "Generated AVD snapshot for caching."
+
     - name: Run Test
       run: ./gradlew test
 
@@ -44,5 +63,8 @@ jobs:
       with:
         api-level: 33
         arch: x86_64
+        force-avd-creation: false
+        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        disable-animations: true
         target: google_apis
         script: ./gradlew connectedAndroidTest

--- a/.github/workflows/tpp-ci.yml
+++ b/.github/workflows/tpp-ci.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        api-level: 29
+        api-level: [29]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tpp-ci.yml
+++ b/.github/workflows/tpp-ci.yml
@@ -56,34 +56,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-java@v3
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-    - name: Build with Gradle 
-      uses: gradle/gradle-build-action@v2
-      with:
-        arguments: build
-
-    - name: AVD cache
-      uses: actions/cache@v3
-      id: avd-cache
-      with:
-        path: |
-          ~/.android/avd/*
-          ~/.android/adb*
-        key: avd-${{ matrix.api-level }}
-
-    - name: create AVD and generate snapshot for caching
-      if: steps.avd-cache.outputs.cache-hit != 'true'
-      uses: reactivecircus/android-emulator-runner@v2
-      with:
-        api-level: ${{ matrix.api-level }}
-        force-avd-creation: false
-        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-        disable-animations: false
-        script: echo "Generated AVD snapshot for caching."
-
     - name: Run Instrumental Tests
       uses: reactivecircus/android-emulator-runner@v2
       with:

--- a/.github/workflows/tpp-ci.yml
+++ b/.github/workflows/tpp-ci.yml
@@ -31,8 +31,10 @@ jobs:
       uses: gradle/gradle-build-action@v2
       with:
         arguments: build
+        cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/test-github-actions-with-emulator' }}
   
   unit-tests:
+    name: Unit Tests
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -49,6 +51,7 @@ jobs:
       run: ./gradlew test
 
   instrumental-tests:
+    name: Instrumental Tests
     runs-on: macOS-latest
     strategy:
       matrix:

--- a/.github/workflows/tpp-ci.yml
+++ b/.github/workflows/tpp-ci.yml
@@ -18,9 +18,7 @@ permissions:
 
 jobs:
   build:
-
-    runs-on: macOS-latest
-
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK 11
@@ -28,17 +26,37 @@ jobs:
       with:
         java-version: '11'
         distribution: 'temurin'
-    - name: Run gradle wrapper
-      run: gradle wrapper
 
     - name: Build with Gradle
       uses: gradle/gradle-build-action@v2
       with:
         arguments: build
+  
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
 
+    - name: Build with Gradle 
+      uses: gradle/gradle-build-action@v2
     - name: Run Test
       run: ./gradlew test
 
+  instrumental-tests:
+    runs-on: macOS-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+
+    - name: Build with Gradle 
+      uses: gradle/gradle-build-action@v2
     - name: Run Instrumental Tests
       uses: reactivecircus/android-emulator-runner@v2
       with:

--- a/.github/workflows/tpp-ci.yml
+++ b/.github/workflows/tpp-ci.yml
@@ -61,6 +61,11 @@ jobs:
       with:
         java-version: '11'
         distribution: 'temurin'
+    - name: Build with Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: build
+
     - name: Run Instrumental Tests
       uses: reactivecircus/android-emulator-runner@v2
       with:

--- a/.github/workflows/tpp-ci.yml
+++ b/.github/workflows/tpp-ci.yml
@@ -36,37 +36,12 @@ jobs:
       with:
         arguments: build
 
-    - name: AVD cache
-      uses: actions/cache@v3
-      id: avd-cache
-      with:
-        path: |
-          ~/.android/avd/*
-          ~/.android/adb*
-        key: avd-33
-
-    - name: create AVD and generate snapshot for caching
-      if: steps.avd-cache.outputs.cache-hit != 'true'
-      uses: reactivecircus/android-emulator-runner@v2
-      with:
-        api-level: 33
-        arch: x86_64
-        target: google_apis
-        force-avd-creation: false
-        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-        disable-animations: false
-        script: echo "Generated AVD snapshot for caching."
-
     - name: Run Test
       run: ./gradlew test
 
     - name: Run Instrumental Tests
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 33
-        arch: x86_64
-        force-avd-creation: false
-        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        api-level: 29
         disable-animations: true
-        target: google_apis
         script: ./gradlew connectedAndroidTest

--- a/.github/workflows/tpp-ci.yml
+++ b/.github/workflows/tpp-ci.yml
@@ -31,6 +31,7 @@ jobs:
       uses: gradle/gradle-build-action@v2
       with:
         arguments: build
+        cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
   
   unit-tests:
     runs-on: ubuntu-latest
@@ -44,6 +45,7 @@ jobs:
       uses: gradle/gradle-build-action@v2
       with:
         arguments: build
+        cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
 
     - name: Run Test
       run: ./gradlew test

--- a/.github/workflows/tpp-ci.yml
+++ b/.github/workflows/tpp-ci.yml
@@ -31,7 +31,6 @@ jobs:
       uses: gradle/gradle-build-action@v2
       with:
         arguments: build
-        cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
   
   unit-tests:
     runs-on: ubuntu-latest
@@ -45,7 +44,6 @@ jobs:
       uses: gradle/gradle-build-action@v2
       with:
         arguments: build
-        cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
 
     - name: Run Test
       run: ./gradlew test
@@ -54,7 +52,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        api-level: [29]
+        api-level: 29
 
     steps:
     - uses: actions/checkout@v3
@@ -63,16 +61,29 @@ jobs:
       with:
         java-version: '11'
         distribution: 'temurin'
-    - name: Build with Gradle
-      uses: gradle/gradle-build-action@v2
+
+    - name: AVD cache
+      uses: actions/cache@v3
+      id: avd-cache
       with:
-        arguments: build
+        path: |
+          ~/.android/avd/*
+          ~/.android/adb*
+        key: avd-${{ matrix.api-level }}
+
+    - name: create AVD and generate snapshot for caching
+      if: steps.avd-cache.outputs.cache-hit != 'true'
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: ${{ matrix.api-level }}
+        force-avd-creation: false
+        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        disable-animations: false
+        script: echo "Generated AVD snapshot for caching."
 
     - name: Run Instrumental Tests
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 29
-        force-avd-creation: false
+        api-level: ${{ matrix.api-level }}
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-        disable-animations: true
         script: ./gradlew connectedAndroidTest


### PR DESCRIPTION
This PR modifies our CI workflow to run build, unit tests, and instrumental tests in parallel.
It also caches gradle builds and AVD so our subsequent runs will be faster.
- Will only write gradle builds to cache in develop and main