### PR TITLE
Added bottom padding to CalendarScreen.kt

### DIFF
--- a/app/src/main/java/com/example/theperiodpurse/ui/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/example/theperiodpurse/ui/calendar/CalendarScreen.kt
@@ -230,10 +230,6 @@ fun CalendarScreenLayout(calendarViewModel: CalendarViewModel, navController: Na
                         }
                     }
                 )
-
-                Spacer(modifier = Modifier.size(36.dp))
-
-
             }
         }
     }

--- a/app/src/main/java/com/example/theperiodpurse/ui/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/example/theperiodpurse/ui/calendar/CalendarScreen.kt
@@ -208,6 +208,7 @@ fun CalendarScreenLayout(calendarViewModel: CalendarViewModel, navController: Na
                     modifier = Modifier
                         .padding(horizontal = 12.dp)
                         .semantics { contentDescription = "Calendar" },
+                    contentPadding = PaddingValues(bottom = 48.dp),
                     state = state,
                     monthHeader = { month ->
                         MonthHeader(month)
@@ -229,6 +230,10 @@ fun CalendarScreenLayout(calendarViewModel: CalendarViewModel, navController: Na
                         }
                     }
                 )
+
+                Spacer(modifier = Modifier.size(36.dp))
+
+
             }
         }
     }


### PR DESCRIPTION
As per [issue #64](https://github.com/uoftblueprint/the-period-purse-2023/issues/64), added bottom padding to add space between the calendar and log symptoms button.