### PR TITLE
Force Kotlin to use LightColorPalette regardless of theme

### DIFF
--- a/app/src/main/java/com/tpp/theperiodpurse/ui/theme/Theme.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/ui/theme/Theme.kt
@@ -1,6 +1,5 @@
 package com.tpp.theperiodpurse.ui.theme
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
@@ -8,16 +7,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
-private val DarkColorPalette = darkColors(
-    primary = Purple200,
-    primaryVariant = Purple700,
-    secondary = Teal200
-)
-
 private val LightColorPalette = lightColors(
-    primary = Purple500,
-    primaryVariant = Purple700,
-    secondary = Teal200
+    primary = Purple500, primaryVariant = Purple700, secondary = Teal200
 
     /* Other default colors to override
     background = Color.White,
@@ -31,14 +22,9 @@ private val LightColorPalette = lightColors(
 
 @Composable
 fun ThePeriodPurseTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
-    val colors = if (darkTheme) {
-        DarkColorPalette
-    } else {
-        LightColorPalette
-    }
+    val colors = LightColorPalette
 
     val systemUiController = rememberSystemUiController()
     systemUiController.setSystemBarsColor(
@@ -49,9 +35,6 @@ fun ThePeriodPurseTheme(
     )
 
     MaterialTheme(
-        colors = colors,
-        typography = Typography,
-        shapes = Shapes,
-        content = content
+        colors = colors, typography = Typography, shapes = Shapes, content = content
     )
 }


### PR DESCRIPTION
Fixes #77

Updated colour palette used in `Theme.kt` regardless of theme (light/dark). Removed check to see whether dark mode was initiated and instead assigned `LightColorPalette` to `colors`. 