### PR TITLE
83 Onboarding Bug Fixes

### DIFF
--- a/app/src/androidTest/java/com/tpp/theperiodpurse/NavigationOnboardTest.kt
+++ b/app/src/androidTest/java/com/tpp/theperiodpurse/NavigationOnboardTest.kt
@@ -165,6 +165,60 @@ class NavigationOnboardTest {
         }
     }
 
+    @Test
+    fun appNavHost_questionone_input_change() {
+        // welcome page
+        navController.assertCurrentRouteName(OnboardingScreen.Welcome.name)
+        // next to quesiton one page
+        composeTestRule.onNodeWithContentDescription("Next").performClick()
+            .performClick()
+        navController.assertCurrentRouteName(OnboardingScreen.QuestionOne.name)
+        val textFieldValue = "5"
+        composeTestRule.onNodeWithContentDescription("Pick Days")
+            .performTextInput(textFieldValue)
+        composeTestRule.onNodeWithContentDescription("Pick Days")
+            .performImeAction()
+
+        composeTestRule.onNodeWithContentDescription("Next").performClick()
+
+        composeTestRule.onNodeWithContentDescription("Skip").performClick()
+
+        composeTestRule.onNodeWithContentDescription("Skip").performClick()
+
+        navController.assertCurrentRouteName(OnboardingScreen.Summary.name)
+
+        composeTestRule.onNodeWithText("5 days").assertExists()
+
+        composeTestRule.onNodeWithContentDescription("Back").performClick()
+
+        composeTestRule.onNodeWithContentDescription("Back").performClick()
+
+        composeTestRule.onNodeWithContentDescription("Back").performClick()
+
+        // back to quesiton one page
+        navController.assertCurrentRouteName(OnboardingScreen.QuestionOne.name)
+
+
+        val newtextFieldValue = "6"
+        composeTestRule.onNodeWithContentDescription("Pick Days")
+            .performTextClearance()
+        composeTestRule.onNodeWithContentDescription("Pick Days")
+            .performTextInput(newtextFieldValue)
+        composeTestRule.onNodeWithContentDescription("Pick Days")
+            .performImeAction()
+
+        composeTestRule.onNodeWithContentDescription("Next").performClick()
+
+        composeTestRule.onNodeWithContentDescription("Skip").performClick()
+
+        composeTestRule.onNodeWithContentDescription("Skip").performClick()
+
+        navController.assertCurrentRouteName(OnboardingScreen.Summary.name)
+
+        composeTestRule.onNodeWithText("6 days").assertExists()
+    }
+
+
 
 
 

--- a/app/src/androidTest/java/com/tpp/theperiodpurse/NavigationOnboardTest.kt
+++ b/app/src/androidTest/java/com/tpp/theperiodpurse/NavigationOnboardTest.kt
@@ -87,7 +87,7 @@ class NavigationOnboardTest {
 //
 
 //        composeTestRule.onNodeWithContentDescription("Next").performClick()
-        composeTestRule.onNodeWithContentDescription("Skip").performClick()
+        composeTestRule.onNodeWithContentDescription("Next").performClick()
         navController.assertCurrentRouteName(OnboardingScreen.Summary.name)
         composeTestRule.onNodeWithText("5 days").assertExists()
         composeTestRule.onNodeWithContentDescription("Mood").assertExists()

--- a/app/src/main/java/com/tpp/theperiodpurse/NavigationGraph.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/NavigationGraph.kt
@@ -13,7 +13,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.navArgument
-import com.tpp.theperiodpurse.MainActivity
 import com.tpp.theperiodpurse.data.*
 import com.tpp.theperiodpurse.ui.SummaryScreen
 import com.tpp.theperiodpurse.ui.calendar.CalendarScreen
@@ -106,21 +105,17 @@ fun NavigationGraph(
         // Onboard Screens
         composable(route = OnboardingScreen.QuestionOne.name) {
             QuestionOneScreen(
-                onNextButtonClicked = { navController.navigate(OnboardingScreen.QuestionTwo.name) },
+                navController = navController,
                 onSelectionChanged = { viewModel.setQuantity(it.toInt()) },
                 navigateUp = { navController.navigateUp() },
                 canNavigateBack = navController.previousBackStackEntry != null,
                 onboardUiState = uiState,
-
-
-
-
             )
         }
         composable(route = OnboardingScreen.QuestionTwo.name) {
             QuestionTwoScreen(
+                navController = navController,
                 onboardUiState = uiState,
-                onNextButtonClicked = { navController.navigate(OnboardingScreen.QuestionThree.name) },
                 onSelectionChanged = { viewModel.setDate(it) },
                 navigateUp = { navController.navigateUp() },
                 canNavigateBack = navController.previousBackStackEntry != null
@@ -129,9 +124,9 @@ fun NavigationGraph(
 
         composable(route = OnboardingScreen.QuestionThree.name) {
             QuestionThreeScreen(
-                onNextButtonClicked = { navController.navigate(OnboardingScreen.Summary.name) },
+                navController = navController,
+                onboardUiState = uiState,
                 onSelectionChanged = { viewModel.setSymptoms(it) },
-                navigateUp = { navController.navigateUp() },
                 canNavigateBack = navController.previousBackStackEntry != null
             )
         }

--- a/app/src/main/java/com/tpp/theperiodpurse/data/OnboardUIState.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/data/OnboardUIState.kt
@@ -1,11 +1,11 @@
 package com.tpp.theperiodpurse.data
 
 data class OnboardUIState(/** Selected days quantity  */
-                          val days: Int = 0,
+                          var days: Int = 0,
                           /** Selected date for pickup (such as "Jan 1") */
-                          val date: String = "",
+                          var date: String = "",
                           /** Available Symptoms dates for the order*/
-                          val symptomsOptions: List<String> = listOf(),
+                          var symptomsOptions: List<String> = listOf(),
                           /** Available dates for the track*/
                           val dateOptions: List<String> = listOf(),
                           val user: User? = null,

--- a/app/src/main/java/com/tpp/theperiodpurse/ui/onboarding/QuestionOneScreen.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/ui/onboarding/QuestionOneScreen.kt
@@ -54,7 +54,12 @@ fun QuestionOneScreen(
     if (periodCycle == ""){
         entered = false
     }
-    backbutton(navigateUp, canNavigateBack)
+    backbutton({
+        onboardUiState.days = 0
+        onboardUiState.symptomsOptions = listOf()
+        onboardUiState.date = ""
+        navController.navigateUp()
+               }, canNavigateBack)
 
     Box(modifier = Modifier
         .fillMaxHeight()

--- a/app/src/main/java/com/tpp/theperiodpurse/ui/onboarding/QuestionThreeScreen.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/ui/onboarding/QuestionThreeScreen.kt
@@ -26,18 +26,31 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
-import com.tpp.theperiodpurse.ui.onboarding.backbutton
-import com.tpp.theperiodpurse.ui.onboarding.background_shape
+import androidx.navigation.NavHostController
+import com.tpp.theperiodpurse.OnboardingScreen
+import com.tpp.theperiodpurse.data.OnboardUIState
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun QuestionThreeScreen(
     onSelectionChanged: (String) -> Unit = {},
-    onNextButtonClicked: () -> Unit = {},
-    navigateUp: () -> Unit,
-    canNavigateBack: Boolean
+    canNavigateBack: Boolean,
+    navController: NavHostController,
+    onboardUiState: OnboardUIState
 ) {
     var selectedValue by rememberSaveable { mutableStateOf("") }
+    var updateList by rememberSaveable { mutableStateOf(false) }
+
+    if (!updateList && onboardUiState.symptomsOptions.isNotEmpty()){
+        onboardUiState.symptomsOptions.forEach { option ->
+            if (option != "" && !selectedValue.contains(option)) {
+                selectedValue = "$selectedValue$option|"
+            }
+        }
+        updateList = true
+
+    }
+
 
     val configuration = LocalConfiguration.current
 
@@ -45,7 +58,10 @@ fun QuestionThreeScreen(
 
     val screenheight = configuration.screenHeightDp;
 
-    Box(Modifier.fillMaxHeight().fillMaxWidth()) {
+    Box(
+        Modifier
+            .fillMaxHeight()
+            .fillMaxWidth()) {
 
 
         Column(
@@ -86,7 +102,7 @@ fun QuestionThreeScreen(
             }
             Text(
                 text = stringResource(R.string.question_three),
-                fontSize = 28.sp,
+                fontSize = (screenheight * (0.035)).sp,
                 modifier = Modifier
                     .align(Alignment.CenterHorizontally)
                     .width(300.dp),
@@ -181,10 +197,10 @@ fun QuestionThreeScreen(
                                     selectedValue = selectedValue + "|" + item
 
                                 }
-                                onSelectionChanged(selectedValue)
                             }
                         )
-                        .padding(horizontal = (screenheight * 0.02).dp).semantics { contentDescription = "Mood" },
+                        .padding(horizontal = (screenheight * 0.02).dp)
+                        .semantics { contentDescription = "Mood" },
                     verticalArrangement = Arrangement.Center,
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
@@ -234,9 +250,9 @@ fun QuestionThreeScreen(
                                     selectedValue = selectedValue + "|" + item
 
                                 }
-                                onSelectionChanged(selectedValue)
                             })
-                        .padding(horizontal = 13.dp).semantics { contentDescription = "fitness" },
+                        .padding(horizontal = 13.dp)
+                        .semantics { contentDescription = "fitness" },
                     verticalArrangement = Arrangement.Center,
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
@@ -288,9 +304,10 @@ fun QuestionThreeScreen(
                                     selectedValue = selectedValue + "|" + item
 
                                 }
-                                onSelectionChanged(selectedValue)
+
                             })
-                        .padding(horizontal = 13.dp).semantics { contentDescription = "Cramps" },
+                        .padding(horizontal = 13.dp)
+                        .semantics { contentDescription = "Cramps" },
                     verticalArrangement = Arrangement.Center,
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
@@ -317,8 +334,6 @@ fun QuestionThreeScreen(
                             )
 
                     }
-
-
                     Text(
                         text = stringResource(R.string.cramps),
                         fontSize = 15.sp,
@@ -345,9 +360,10 @@ fun QuestionThreeScreen(
                                     selectedValue = selectedValue + "|" + item
 
                                 }
-                                onSelectionChanged(selectedValue)
+
                             })
-                        .padding(horizontal = 13.dp).semantics { contentDescription = "Exercise" },
+                        .padding(horizontal = 13.dp)
+                        .semantics { contentDescription = "Exercise" },
                     verticalArrangement = Arrangement.Center,
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
@@ -356,7 +372,8 @@ fun QuestionThreeScreen(
                         modifier = Modifier
                             .height(50.dp)
                             .width(50.dp)
-                            .clip(RoundedCornerShape(30)).semantics { contentDescription = "Sleep" }
+                            .clip(RoundedCornerShape(30))
+                            .semantics { contentDescription = "Sleep" }
                             .then(
                                 if (!selectedValue.contains("Sleep")) Modifier.background(Color.White) else Modifier.background(
                                     Color(rgb(142, 212, 193))
@@ -374,30 +391,31 @@ fun QuestionThreeScreen(
                             )
 
                     }
-
-
                     Text(
                         text = stringResource(R.string.sleep),
                         fontSize = 15.sp,
 
                         )
-
                 }
-
-
             }
-
-
         }
         Row(
-            modifier = Modifier.fillMaxWidth().align(Alignment.BottomCenter).padding(bottom = (screenheight * (0.03)).dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomCenter)
+                .padding(bottom = (screenheight * (0.01)).dp),
             horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             TextButton(
                 modifier = Modifier
                     .padding(start = (screenwidth * (0.1)).dp)
-                    .weight(1f).semantics { contentDescription = "Skip" },
-                onClick = onNextButtonClicked,
+                    .weight(1f)
+                    .semantics { contentDescription = "Skip" },
+                onClick = {
+                    onSelectionChanged("")
+                    navController.navigate(OnboardingScreen.Summary.name)
+
+                },
                 colors = ButtonDefaults.buttonColors(backgroundColor = Color.Transparent)
             ) {
                 Text(
@@ -409,10 +427,14 @@ fun QuestionThreeScreen(
             Button(
                 modifier = Modifier
                     .padding(end = (screenwidth * (0.1)).dp)
-                    .weight(1f).semantics { contentDescription = "Next" },
+                    .weight(1f)
+                    .semantics { contentDescription = "Next" },
                 // the button is enabled when the user makes a selection
-                enabled = selectedValue.isNotEmpty(),
-                onClick = onNextButtonClicked,
+                enabled = selectedValue.replace("|","").isNotEmpty(),
+                onClick = {
+                    onSelectionChanged(selectedValue)
+                    navController.navigate(OnboardingScreen.Summary.name)
+                },
                 colors = ButtonDefaults.buttonColors(backgroundColor = Color(97, 153, 154))
             ) {
                 Text(stringResource(R.string.next), color = Color.White, fontSize = 20.sp)
@@ -421,7 +443,10 @@ fun QuestionThreeScreen(
 
     }
 
-    backbutton(navigateUp, canNavigateBack)
+    backbutton({
+        navController.navigateUp()
+        onSelectionChanged(selectedValue)
+               }, canNavigateBack)
 }
 
 

--- a/app/src/main/java/com/tpp/theperiodpurse/ui/onboarding/QuestionTwoScreen.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/ui/onboarding/QuestionTwoScreen.kt
@@ -54,6 +54,8 @@ fun QuestionTwoScreen(
         entered = true
     }
 
+
+
     val mDateTo = remember { mutableStateOf("") }
     val mCalendar = Calendar.getInstance()
 

--- a/app/src/main/java/com/tpp/theperiodpurse/ui/onboarding/QuestionTwoScreen.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/ui/onboarding/QuestionTwoScreen.kt
@@ -23,32 +23,35 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.navigation.NavHostController
+import com.tpp.theperiodpurse.OnboardingScreen
 import com.tpp.theperiodpurse.R
 import com.tpp.theperiodpurse.data.OnboardUIState
 import java.text.SimpleDateFormat
 import java.util.*
-import java.util.function.Predicate.not
 
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun QuestionTwoScreen(
     onboardUiState: OnboardUIState,
-    onNextButtonClicked: () -> Unit,
     onSelectionChanged: (String) -> Unit = {},
     modifier: Modifier = Modifier,
     navigateUp: () -> Unit,
-    canNavigateBack: Boolean
+    canNavigateBack: Boolean,
+    navController: NavHostController
 ) {
     val mYear: Int
     val mMonth: Int
     val mDay: Int
     val mContext = LocalContext.current
+    var entered by rememberSaveable { mutableStateOf(false) }
 
     val mDate = rememberSaveable { mutableStateOf("Choose date") }
 
-    if ((onboardUiState.date.equals("/"))){
-        mDate.value = onboardUiState.date
+    if (onboardUiState.date.contains("/")){
+        mDate.value = onboardUiState.date.split(" to ")[0]
+        entered = true
     }
 
     val mDateTo = remember { mutableStateOf("") }
@@ -58,7 +61,7 @@ fun QuestionTwoScreen(
     mMonth = mCalendar.get(Calendar.MONTH)
     mDay = mCalendar.get(Calendar.DAY_OF_MONTH)
 
-    var entered by remember { mutableStateOf(false) }
+
 
     val mDatePickerDialog = DatePickerDialog(
         mContext,
@@ -97,11 +100,9 @@ fun QuestionTwoScreen(
                 modifier = Modifier
                     .width(screenwidth.dp)
                     .height(height.dp)
-
             )
             {
                 background_shape()
-
                 Image(
                     painter = painterResource(R.drawable.flow_with_heart),
                     contentDescription = null,
@@ -110,7 +111,6 @@ fun QuestionTwoScreen(
                         .align(Alignment.Center),
                 )
                 val barheight1 = (screenheight * (0.09))
-
                 Image(
                     painter = painterResource(R.drawable.onboard_bar2),
                     contentDescription = null,
@@ -118,12 +118,10 @@ fun QuestionTwoScreen(
                         .size(barheight1.dp)
                         .align(Alignment.BottomCenter),
                 )
-
             }
-
             Text(
                 text = stringResource(R.string.question_two),
-                fontSize = 30.sp,
+                fontSize = (screenheight * (0.035)).sp,
                 modifier = Modifier
                     .align(Alignment.CenterHorizontally)
                     .width(250.dp),
@@ -140,18 +138,17 @@ fun QuestionTwoScreen(
                 textAlign = TextAlign.Center
             )
             Spacer(Modifier.height((screenheight * (0.02)).dp))
-
-
-
             Button(
                 onClick = {
                     mDatePickerDialog.show()
                     entered = true
                 }, colors = ButtonDefaults.buttonColors(backgroundColor = Color.White),
                 modifier = modifier
-                    .width(175.dp).semantics { contentDescription = "datepick" },
+                    .width(175.dp)
+                    .semantics { contentDescription = "datepick" },
                 shape = RoundedCornerShape(20)
             ) {
+                if (mDate.value.contains("Choose date")){
                     Row(
                         modifier = Modifier
                             .padding(
@@ -163,59 +160,73 @@ fun QuestionTwoScreen(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.Center
                     ) {
+                        Text(text = mDate.value, color = Color.Gray, fontSize = 14.sp)
 
-                        Text(text = onboardUiState.date.split(" to ")[0], color = Color.Black, fontSize = 18.sp)
-
+                        Image(
+                            painter = painterResource(R.drawable.onboard_calendar),
+                            contentDescription = null,
+                            modifier = Modifier.padding(start = 10.dp, end=0.dp),
+                        )
+                    }
+                }
+                else {
+                    Row(
+                        modifier = Modifier
+                            .padding(
+                                start = 12.dp,
+                                end = 12.dp,
+                                top = 12.dp,
+                                bottom = 12.dp
+                            ),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center
+                    ) {
+                        Text(text = mDate.value, color = Color.Black, fontSize = 18.sp)
                     }
 
-
-
-
+                }
 
 
             }
-
             Spacer(Modifier.height((screenwidth * (0.02)).dp))
-
-
         }
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .align(Alignment.BottomCenter)
-                .padding(bottom = (screenheight * (0.05)).dp),
+                .padding(bottom = (screenheight * (0.03)).dp),
             horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             TextButton(
-                onClick = onNextButtonClicked,
+                onClick = {
+                    onboardUiState.date = "Choose date"
+                    navController.navigate(OnboardingScreen.QuestionThree.name)
+                          },
                 modifier = modifier
                     .padding(start = (screenwidth * (0.1)).dp)
-                    .weight(1f).semantics { contentDescription = "Skip" },
+                    .weight(1f)
+                    .semantics { contentDescription = "Skip" },
                 colors = ButtonDefaults.buttonColors(backgroundColor = Color.Transparent)
 
             ) {
                 Text(stringResource(R.string.skip), color = Color(97, 153, 154), fontSize = 20.sp)
             }
             Button(
-                onClick = onNextButtonClicked,
+                onClick = {
+                    onSelectionChanged(mDate.value + "|" + mDateTo.value)
+                    navController.navigate(OnboardingScreen.QuestionThree.name)
+                          },
                 enabled = entered,
                 modifier = modifier
                     .padding(end = (screenwidth * (0.1)).dp)
-                    .weight(1f).semantics { contentDescription = "Next" },
+                    .weight(1f)
+                    .semantics { contentDescription = "Next" },
                 colors = ButtonDefaults.buttonColors(backgroundColor = Color(97, 153, 154))
             ) {
                 Text(stringResource(R.string.next), color = Color.White, fontSize = 20.sp)
-                onSelectionChanged(mDate.value + "|" + mDateTo.value)
-
             }
-
         }
     }
-
-
-
-
-
 }
 
 fun setDateTo(day: Int, month: Int, year: Int, range: Int): String {

--- a/app/src/main/java/com/tpp/theperiodpurse/ui/onboarding/SummaryScreen.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/ui/onboarding/SummaryScreen.kt
@@ -55,7 +55,7 @@ fun SummaryScreen(
 
         ) {
 
-        Spacer(modifier = Modifier.height((screenheight * (0.15)).dp))
+        Spacer(modifier = Modifier.height((screenheight * (0.12)).dp))
 
 
         Image(
@@ -97,7 +97,7 @@ fun SummaryScreen(
             )
         }
 
-        if (!onboardUiState.date.contains("Choose date to")) {
+        if (!onboardUiState.date.contains("Choose date")) {
 
             Column(Modifier.padding(start = 25.dp)) {
                 Text(


### PR DESCRIPTION
Here are the following features / bugs in the onboarding that were fixed/ implemented:

1. able to edit TextField on Question One Page when navigated back
2. fixed screen for smaller devices (e.g pixel 2) -> made more responsive
3. fixed skip button / next button behaviour 
  - the expected behaviour: when pressing skip on a page, all data that was given on that page would reset in the summary screen. However, progress on the respective page should still be remembered for when user navigates back
  - the actual behaviour before the fix: still acts as a "next button"
  - added tests to distinguish features
4. Question Two and Three viewmodel data inputs persists when navigated to a page before it 
5. implemented extra tests for coverage of bugs
6. full reset in data inputs in the onboarding when user navigates back to welcome page


If there are any questions feel free to contact or comment. Thanks.
