### PR TITLE
Fixed duplicate entry bug

### DIFF
--- a/app/src/main/java/com/tpp/theperiodpurse/data/Date.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/data/Date.kt
@@ -7,8 +7,7 @@ import java.util.Date
 
 @Entity(tableName = "dates")
 data class Date (
-    @PrimaryKey(autoGenerate = true)
-    val id: Int = 0,
+    @PrimaryKey
     @TypeConverters(DaysConverter::class)
     val date: Date?,
     val flow: FlowSeverity?,

--- a/app/src/main/java/com/tpp/theperiodpurse/data/dateDAO.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/data/dateDAO.kt
@@ -5,8 +5,6 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface DateDAO {
-    @Query("SELECT * FROM dates WHERE id = :id")
-    fun get(id: Int): Date
     @Query("SELECT * FROM dates")
     fun getDates(): Flow<List<Date>>
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/app/src/main/java/com/tpp/theperiodpurse/ui/symptomlog/LogScreen.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/ui/symptomlog/LogScreen.kt
@@ -122,7 +122,7 @@ fun LogScreen(
                         Date(
                             date = Date1.from(
                                 LocalDateTime.of(
-                                    day, LocalDateTime.now().toLocalTime()
+                                    day, LocalDateTime.MIN.toLocalTime()
                                 ).atZone(ZoneId.systemDefault()).toInstant()
                             ),
                             flow = logViewModel.getSquareSelected(LogPrompt.Flow)


### PR DESCRIPTION
This pull requests is a fix for the duplicate entries in database. The implementation includes setting date as a primary key and also standardizing the dates. This also meant removing the old primary key, the id field, and its getId query as it served no function and was not being used.