### PR TITLE
Fixed scrolling on EducationInfoScreen.kt

### DIFF
--- a/app/src/main/java/com/tpp/theperiodpurse/ui/education/EducationInfoScreen.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/ui/education/EducationInfoScreen.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -19,9 +21,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
-import com.tpp.theperiodpurse.R
 import com.tpp.theperiodpurse.data.Product
 import com.tpp.theperiodpurse.data.ProductsList
+import com.tpp.theperiodpurse.R
+
 
 @Composable
 fun EducationInfoScreen(
@@ -42,6 +45,7 @@ fun EducationInfoScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .verticalScroll(rememberScrollState())
             .padding(24.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {


### PR DESCRIPTION
As per [issue #85](https://github.com/uoftblueprint/the-period-purse-2023/issues/85), I added scrolling onto the Education Info Screen so the screen doesn't get cut off for smaller devices.