### PR TITLE
[BUG FIX] Fixed Calendar Update Bug after onboarding / deleting new account

### DIFF
--- a/app/src/main/java/com/tpp/theperiodpurse/AppScreen.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/AppScreen.kt
@@ -206,7 +206,6 @@ fun ScreenApp(
     context: Context,
 
 ) {
-    appViewModel.loadData(calendarViewModel)
     var loggingOptionsVisible by remember { mutableStateOf(false) }
     var skipOnboarding = skipOnboarding
     val isOnboarded by onboardViewModel.isOnboarded.observeAsState(initial = null)
@@ -242,7 +241,7 @@ fun ScreenApp(
             Box {
                 NavigationGraph(
                     navController = navController,
-                    startDestination = if (skipOnboarding) Screen.Calendar.name else if (skipWelcome) OnboardingScreen.QuestionOne.name else OnboardingScreen.Welcome.name,
+                    startDestination = if (skipOnboarding) OnboardingScreen.LoadDatabase.name else if (skipWelcome) OnboardingScreen.QuestionOne.name else OnboardingScreen.Welcome.name,
                     onboardViewModel = onboardViewModel,
                     appViewModel= appViewModel,
                     calendarViewModel = calendarViewModel,

--- a/app/src/main/java/com/tpp/theperiodpurse/AppViewModel.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/AppViewModel.kt
@@ -1,6 +1,8 @@
 package com.tpp.theperiodpurse
 
 import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.tpp.theperiodpurse.data.Date
@@ -28,6 +30,7 @@ class AppViewModel @Inject constructor (
 ): ViewModel() {
     private val _uiState = MutableStateFlow(AppUiState())
     val uiState: StateFlow<AppUiState> = _uiState.asStateFlow()
+    var isLoaded: MutableLiveData<Boolean?> = MutableLiveData(null)
 
     fun loadData(calendarViewModel: CalendarViewModel) {
         val trackedSymptoms: MutableList<Symptom> = mutableListOf()
@@ -80,8 +83,8 @@ class AppViewModel @Inject constructor (
                     }
                 }
             }
-
         }
+        isLoaded.postValue(true)
     }
 
     fun getTrackedSymptoms() : List<Symptom> {

--- a/app/src/main/java/com/tpp/theperiodpurse/NavigationGraph.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/NavigationGraph.kt
@@ -21,6 +21,7 @@ import com.tpp.theperiodpurse.ui.calendar.CalendarViewModel
 import com.tpp.theperiodpurse.ui.cycle.CycleScreenLayout
 import com.tpp.theperiodpurse.ui.education.*
 import com.tpp.theperiodpurse.ui.onboarding.*
+import com.tpp.theperiodpurse.ui.setting.LoadDatabase
 import com.tpp.theperiodpurse.ui.setting.SettingsScreen
 import com.tpp.theperiodpurse.ui.symptomlog.LogScreen
 
@@ -38,6 +39,7 @@ enum class OnboardingScreen {
     QuestionTwo,
     QuestionThree,
     Summary,
+    LoadDatabase,
 }
 
 @RequiresApi(Build.VERSION_CODES.S)
@@ -150,9 +152,8 @@ fun NavigationGraph(
             SummaryScreen(
                 onboardUiState = onboardUIState,
                 onSendButtonClicked = {
-                    navController.popBackStack(OnboardingScreen.Welcome.name, inclusive = true)
-                    navController.navigate(Screen.Calendar.name)
-                    appViewModel.loadData(calendarViewModel)
+                    navController.navigate(OnboardingScreen.LoadDatabase.name)
+
                 },
                 navigateUp = { navController.navigateUp() },
                 canNavigateBack = navController.previousBackStackEntry != null,
@@ -160,6 +161,13 @@ fun NavigationGraph(
 //                onCancelButtonClicked = {
 //                    cancelOrderAndNavigateToStart(onboardViewModel, navController)
 //                },
+            )
+        }
+        composable(route = OnboardingScreen.LoadDatabase.name) {
+            LoadDatabase(
+                appViewModel = appViewModel,
+                calViewModel = calendarViewModel,
+                navController = navController
             )
         }
     }

--- a/app/src/main/java/com/tpp/theperiodpurse/data/ApplicationRoomDatabase.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/data/ApplicationRoomDatabase.kt
@@ -6,7 +6,7 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 
-@Database(entities=[User::class, Date::class], version = 4, exportSchema = false)
+@Database(entities=[User::class, Date::class], version = 5, exportSchema = false)
 @TypeConverters(
     SymptomConverter::class,
     DateConverter::class,

--- a/app/src/main/java/com/tpp/theperiodpurse/data/UserRepository.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/data/UserRepository.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import com.tpp.theperiodpurse.AppViewModel
+import com.tpp.theperiodpurse.ui.calendar.CalendarViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/tpp/theperiodpurse/ui/onboarding/LoadDatabase.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/ui/onboarding/LoadDatabase.kt
@@ -1,0 +1,47 @@
+package com.tpp.theperiodpurse.ui.setting
+
+
+import android.content.Context
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.navigation.NavHostController
+import com.tpp.theperiodpurse.AppUiState
+import com.tpp.theperiodpurse.AppViewModel
+import com.tpp.theperiodpurse.OnboardingScreen
+import com.tpp.theperiodpurse.Screen
+import com.tpp.theperiodpurse.data.OnboardUIState
+import com.tpp.theperiodpurse.ui.calendar.CalendarUIState
+import com.tpp.theperiodpurse.ui.calendar.CalendarViewModel
+import com.tpp.theperiodpurse.ui.onboarding.LoadingScreen
+import com.tpp.theperiodpurse.ui.onboarding.OnboardViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun LoadDatabase(
+    navController: NavHostController,
+    appViewModel: AppViewModel,
+    calViewModel: CalendarViewModel,
+) {
+    val isLoaded by appViewModel.isLoaded.observeAsState(initial = null)
+
+
+    appViewModel.loadData(calViewModel)
+
+    if (isLoaded == null){
+        LoadingScreen()
+    }
+    else {
+        LaunchedEffect(Unit) {
+            navController.popBackStack(OnboardingScreen.Welcome.name, inclusive = true)
+            navController.navigate(Screen.Calendar.name)
+        }
+
+    }
+
+}

--- a/app/src/main/java/com/tpp/theperiodpurse/ui/onboarding/LoadingScreen.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/ui/onboarding/LoadingScreen.kt
@@ -21,7 +21,6 @@ import com.tpp.theperiodpurse.R
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun LoadingScreen() {
-    val configuration = LocalConfiguration.current
     val redLoading = Color(195, 50, 50)
 
     Image(

--- a/app/src/main/java/com/tpp/theperiodpurse/ui/onboarding/SummaryScreen.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/ui/onboarding/SummaryScreen.kt
@@ -216,7 +216,6 @@ fun SummaryScreen(
                     getDaysSince(onboardUiState.date)
                 )
 
-
                 onSendButtonClicked() },
             colors = ButtonDefaults.buttonColors(backgroundColor = Color(97, 153, 154))
 


### PR DESCRIPTION
Hello everyone,

There was a bug where when a user completes onboarding or deletes an account, the calendar log after the user onboards is completely blank without the updated symptom log options that they selected.

The issue was that we navigated the user to the calendar page right away without letting appviewmodel.loaddate() finish loading in the data so that even thoughthe calendarviewmodel is updated it was too late and the screen doesn't update for the user.

I fixed this by implementing a LoadDatabase compose function where it shows a loading screen until after  appviewmodel.loaddate() which then we can navigate the user to the calendar screen. 

If there are any issues or concerns please let me know. 

Thanks,
Kevin Le