### PR TITLE
107 bug log symptom page unselecting a selected symptom does not remove it

### DIFF
--- a/app/src/main/java/com/tpp/theperiodpurse/AppViewModel.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/AppViewModel.kt
@@ -1,7 +1,6 @@
 package com.tpp.theperiodpurse
 
 import android.util.Log
-import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -157,5 +156,9 @@ class AppViewModel @Inject constructor (
 
     fun saveDate(date: Date) {
         dateRepository.addDate(date)
+    }
+
+    fun deleteDate(date: Date) {
+        dateRepository.deletDate(date)
     }
 }

--- a/app/src/main/java/com/tpp/theperiodpurse/data/DateRepository.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/data/DateRepository.kt
@@ -17,4 +17,10 @@ class DateRepository(private val dateDAO: DateDAO) {
     fun getAllDates(): Flow<List<Date>> {
         return dateDAO.getDates()
     }
+
+    fun deletDate(date: Date) {
+        coroutineScope.launch (Dispatchers.IO) {
+            dateDAO.delete(date)
+        }
+    }
 }

--- a/app/src/main/java/com/tpp/theperiodpurse/ui/symptomlog/LogScreen.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/ui/symptomlog/LogScreen.kt
@@ -86,18 +86,27 @@ fun LogScreen(
         LogScreenLayout(
             day, navController, logPrompts, logViewModel,
             onSave = {
+                navController.navigateUp()
+                // If None is selected, it should not count is a square is filled
+                var flow = logViewModel.getSelectedFlow()
+                if (flow != null && flow.name == "None") {
+                    flow = null
+                }
+                var cramps = logViewModel.getSelectedCrampSeverity()
+                if (cramps != null && cramps.name == "None") {
+                    cramps = null
+                }
                 calendarViewModel.setDayInfo(
                     day,
                     CalendarDayUIState(
-                        flow = logViewModel.getSelectedFlow(),
+                        flow = flow,
                         mood = logViewModel.getSelectedMood(),
                         exerciseLengthString = logViewModel.getText(LogPrompt.Exercise),
                         exerciseType = logViewModel.getSelectedExercise(),
-                        crampSeverity = logViewModel.getSelectedCrampSeverity(),
+                        crampSeverity = cramps,
                         sleepString = logViewModel.getText(LogPrompt.Sleep)
                     )
                 )
-                navController.navigateUp()
                 if (logViewModel.isFilled()) {
                     var exercisedDuration: Duration? = null
                     val excTxt = logViewModel.getText(LogPrompt.Exercise)
@@ -138,6 +147,18 @@ fun LogScreen(
                             notes = logViewModel.getText(LogPrompt.Notes)
                         )
                     )
+                } else {
+                    // chcek  if given date is in the db, if it is, delete the entry
+                    val dates = appViewModel.getDates()
+                    for (d in dates) {
+                        val thisDate = d.date?.toInstant()?.atZone(ZoneId.systemDefault())
+                            ?.toLocalDate()
+                        if (thisDate != null) {
+                            if (thisDate == day) {
+                                appViewModel.deleteDate(d)
+                            }
+                        }
+                    }
                 }
             })
 

--- a/app/src/main/java/com/tpp/theperiodpurse/ui/symptomlog/LogViewModel.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/ui/symptomlog/LogViewModel.kt
@@ -8,13 +8,12 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 
-class LogViewModel(logPrompts: List<LogPrompt>) : ViewModel() {
+class LogViewModel(val logPrompts: List<LogPrompt>) : ViewModel() {
     private val _uiState = MutableStateFlow(LogUiState(
         getSquares(logPrompts),
         getText(logPrompts)
     ))
     val uiState: StateFlow<LogUiState> = _uiState.asStateFlow()
-    val logPrompts = logPrompts
 
     fun populateWithUIState(dayUIState: CalendarDayUIState) {
         _uiState.update { currentState ->
@@ -127,7 +126,7 @@ class LogViewModel(logPrompts: List<LogPrompt>) : ViewModel() {
     }
 
     private fun getSquares(logPrompts: List<LogPrompt>): LinkedHashMap<Int, Any> {
-        var selectedSquares = LinkedHashMap<Int, Any>()
+        val selectedSquares = LinkedHashMap<Int, Any>()
         for (logPrompt in logPrompts) {
             selectedSquares[logPrompt.title] = false
         }
@@ -143,8 +142,21 @@ class LogViewModel(logPrompts: List<LogPrompt>) : ViewModel() {
     }
 
     fun isFilled(): Boolean {
-        logPrompts.forEach() { it ->
-            if (this.getSquareSelected(it) != null || this.getText(it) != "") {
+        logPrompts.forEach() {it ->
+            // For Flow, Cramps, check not null and not None to return true
+            // For Sleep, Excercise, Mood, check not null to return true
+            // For Notes, check not empty to return true
+            if (it == LogPrompt.Flow || it == LogPrompt.Cramps) {
+                if (this.getSquareSelected(it) != null && this.getSquareSelected(it) != "None") {
+                    return true
+                }
+            }
+            if (it == LogPrompt.Sleep || it == LogPrompt.Mood || it == LogPrompt.Exercise) {
+                if (this.getSquareSelected(it) != null) {
+                    return true
+                }
+            }
+            if (it == LogPrompt.Notes && this.getText(it) != "") {
                 return true
             }
         }


### PR DESCRIPTION
Closes #107 

- Added condition to treat `"None"` the same as `null`, so that it is not logged into the database or the view model
- Removes Date entries when a date is deemed to be not logged. i.e. either `"None"` or `null` are selected for `LogPrompts.Flow` and other log prompts