### PR TITLE
Ovulation Entity Refactor

### DIFF
--- a/app/schemas/com.tpp.theperiodpurse.data.ApplicationRoomDatabase/10.json
+++ b/app/schemas/com.tpp.theperiodpurse.data.ApplicationRoomDatabase/10.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 9,
+    "version": 10,
     "identityHash": "5c7f0165b01eaa14cbdfddaa5ed41dbc",
     "entities": [
       {

--- a/app/src/main/java/com/tpp/theperiodpurse/data/entity/Date.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/data/entity/Date.kt
@@ -9,6 +9,7 @@ import com.tpp.theperiodpurse.data.model.CrampSeverity
 import com.tpp.theperiodpurse.data.model.Exercise
 import com.tpp.theperiodpurse.data.model.FlowSeverity
 import com.tpp.theperiodpurse.data.model.Mood
+import com.tpp.theperiodpurse.data.model.Ovulation
 import java.time.Duration
 import java.util.Date
 
@@ -26,5 +27,5 @@ data class Date(
     @TypeConverters(DurationConverter::class)
     val sleep: Duration?,
     val notes: String,
-    val ovulating: Boolean? = false // Merrick: Default Value here to prevent build errors. Will probably get rid of this.
+    val ovulating: Ovulation? = null
 )

--- a/app/src/main/java/com/tpp/theperiodpurse/data/model/Ovulation.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/data/model/Ovulation.kt
@@ -1,0 +1,12 @@
+package com.tpp.theperiodpurse.data.model
+
+enum class Ovulation(val displayName: String) {
+    Ovulating("Ovulating"),
+    Predicted("Predicted")
+    ;
+    companion object {
+        fun getOvulationByDisplayName(displayName: String): Ovulation? {
+            return Ovulation.values().find { it.displayName == displayName }
+        }
+    }
+}

--- a/app/src/main/java/com/tpp/theperiodpurse/ui/calendar/ColorAndIconHelper.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/ui/calendar/ColorAndIconHelper.kt
@@ -112,8 +112,9 @@ private fun sleepScoreOptions(calendarDayUIState: CalendarDayUIState, defaultCol
 }
 
 private fun ovulationOptions(calendarDayUIState: CalendarDayUIState, default: Pair<Color, Int>): Pair<Color, Int> {
-    if (calendarDayUIState.ovulating == true) {
-        return Pair(Color(0xFF69DAC6), R.drawable.ovulation_egg_24dp)
+    return when (calendarDayUIState.ovulating) {
+        Ovulation.Ovulating -> Pair(Color(0xFF69DAC6), R.drawable.ovulation_egg_24dp)
+        Ovulation.Predicted -> Pair(Color(0xFF55AD9E), R.drawable.blank)
+        null -> default
     }
-    return default
 }

--- a/app/src/main/java/com/tpp/theperiodpurse/ui/state/CalendarDayUIState.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/ui/state/CalendarDayUIState.kt
@@ -11,7 +11,7 @@ data class CalendarDayUIState(
     val exerciseType: Exercise? = null,
     val crampSeverity: CrampSeverity? = null,
     val sleepString: String = "",
-    val ovulating: Boolean? = null,
+    val ovulating: Ovulation? = null,
 ) {
     private val formatter = DateTimeFormatter.ISO_LOCAL_TIME
 


### PR DESCRIPTION
Changed the `ovulating` field of the `Date` entity to be of type `Ovulation`. `Ovulation` is a enum that has two values, `Ovulating` and `Predicted`.

The purpose of this change is to make supporting prediction and logging of ovulation more in align with already existing features.