### PR TITLE
the ovulation calender render is done

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="app">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/.idea/migrations.xml
+++ b/.idea/migrations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectMigrations">
+    <option name="MigrateToGradleLocalJavaHome">
+      <set>
+        <option value="$PROJECT_DIR$" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/app/src/main/java/com/tpp/theperiodpurse/data/model/FlowSeverity.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/data/model/FlowSeverity.kt
@@ -6,7 +6,8 @@ enum class FlowSeverity(val displayName: String) {
     Heavy("Heavy"),
     Spotting("Spotting"),
     None("None"),
-    Predicted("Predicted")
+    Predicted("Predicted"),
+    Ovulation(displayName = "Ovulation")
     ;
 
     companion object {

--- a/app/src/main/java/com/tpp/theperiodpurse/ui/calendar/CalenderScreenLayout.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/ui/calendar/CalenderScreenLayout.kt
@@ -76,7 +76,8 @@ fun CalendarScreenLayout(
         }
 
         predictedOvulationDates.forEach{
-            calendarViewModel.setDayInfo(it, CalendarDayUIState(null, ovulating = Ovulation.Predicted))
+            calendarViewModel.setDayInfo(it, CalendarDayUIState(flow = FlowSeverity.Ovulation, ovulating = Ovulation.Predicted))
+            //calendarViewModel.setDayInfo(it, CalendarDayUIState(null, ovulating = Ovulation.Predicted))
         }
     }
 

--- a/app/src/main/java/com/tpp/theperiodpurse/ui/calendar/ColorAndIconHelper.kt
+++ b/app/src/main/java/com/tpp/theperiodpurse/ui/calendar/ColorAndIconHelper.kt
@@ -38,6 +38,7 @@ private fun flowOptions(calendarDayUIState: CalendarDayUIState, default: Pair<Co
         FlowSeverity.Heavy -> Pair(Color(0xFFC33232), R.drawable.flow_heavy)
         FlowSeverity.Spotting -> Pair(Color(0xFFF5C0C0), R.drawable.spotting)
         FlowSeverity.Predicted -> Pair(Color(0xFFEEC6FE), R.drawable.blank)
+        FlowSeverity.Ovulation -> Pair(Color(0xFF55AD9E), R.drawable.blank)
         FlowSeverity.None, null -> default
     }
 }


### PR DESCRIPTION
## Description

[Linear Ticket](https://linear.app/the-period-purse/issue/TPPDEV-69/add-ovulation-predictions-to-period-page) 

I added ovulation tracking to the period tab in the calendar. When if the user manually enters a date it will predict the next ovulation dates.
## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
